### PR TITLE
Add go-releaser for releasing binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -4,42 +4,31 @@ on:
     types:
       - created
 jobs:
-  binaries:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            asset_name: api-linux-amd64.tar.gz
-            compress_cmd: tar -czvf
-            build_cmd: docker run -v $PWD:/data golang:1.19 bash -c "git config --global --add safe.directory /data && cd /data && go build ./cmd/api"
-          - os: windows-latest
-            asset_name: api-windows-amd64.zip
-            compress_cmd: tar.exe -a -c -f
-            build_cmd: go build -o api ./cmd/api
-          - os: macos-latest
-            asset_name: api-darwin-amd64.tar.gz
-            compress_cmd: tar -czvf
-            build_cmd: go build -o api ./cmd/api
-    runs-on: ${{ matrix.os }}
+  binaries:        
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/goreleaser/goreleaser-cross:v1.18
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:          
+          submodules: 'true'
+      - name: Fetch repo
+        run: git fetch --prune --unshallow      
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: v1.19.x
-      - name: Build binary
-        run: ${{ matrix.build_cmd }}
-      - name: Pack output
-        run: ${{ matrix.compress_cmd }} ${{ matrix.asset_name }} api
-      - name: Upload binary
-        uses: svenstaro/upload-release-action@v2
+      - name: Release
+        uses: goreleaser/goreleaser-action@v4
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.asset_name }}
-          asset_name: ${{ matrix.asset_name }}
-          tag: ${{ github.ref_name }}
-          overwrite: true
+          distribution: goreleaser
+          version: latest
+          # skip git checks for testing
+          # --snapshot is used for testing; it doesn't publish artifacts
+          args: release --clean --skip-validate --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -4,14 +4,14 @@ on:
     types:
       - created
 jobs:
-  binaries:        
+  binaries:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/goreleaser/goreleaser-cross:v1.18
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        with:          
+        with:
           submodules: 'true'
       - name: Fetch repo
         run: git fetch --prune --unshallow      
@@ -24,11 +24,9 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          # skip git checks for testing
-          # --snapshot is used for testing; it doesn't publish artifacts
-          args: release --clean --skip-validate --snapshot
+          args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -16,9 +16,9 @@ jobs:
         with:          
           submodules: 'true'
       - run: git fetch --prune --unshallow
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v3
         with:
-          go-version: stable            
+          go-version: v1.19.x            
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -24,6 +24,7 @@ jobs:
           distribution: goreleaser
           version: latest
           # skip git checks for testing
-          args: release --clean --skip-validate
+          # --snapshot is used for testing; it doesn't publish artifacts
+          args: release --clean --skip-validate --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,12 +8,14 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/goreleaser/goreleaser-cross:v1.18
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - run: git fetch --force --tags
+        with:          
+          submodules: 'true'
+      - run: git fetch --prune --unshallow
       - uses: actions/setup-go@v4
         with:
           go-version: stable            

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          # skip git checks for testing
+          args: release --clean --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,26 @@
+name: Release with Goreleaser
+on:
+  push:
+    branches:
+      - avichalp/goreleaser
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: stable            
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,5 +1,9 @@
 # goreleaser.yml
 
+before:
+  hooks:
+  - go mod tidy
+
 project_name: api
 
 builds:
@@ -14,7 +18,9 @@ builds:
     - arm64
   ignore:
     - goos: linux
-      goarch: arm64  
+      goarch: arm64
+  env:
+    - CGO_ENABLED=1
   ldflags: -s -w
 - binary: api-win
   id: api-win
@@ -23,6 +29,8 @@ builds:
     - windows
   goarch:
     - amd64    
+  env:
+    - CGO_ENABLED=1
   ldflags: -s -w
   
 archives:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -22,7 +22,7 @@ builds:
   flags: 
     - -trimpath
   ldflags:
-    - -s -w
+    - -s -w -X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}}
 - id: api-darwin-arm64
   binary: api
   main: ./cmd/api
@@ -36,7 +36,7 @@ builds:
   flags: 
     - -trimpath
   ldflags: 
-    - -s -w
+    - -s -w -X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}}
 - id: api-linux-amd64
   binary: api
   main: ./cmd/api
@@ -50,7 +50,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - -s -w
+    - -s -w -X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}}
 - id: api-linux-arm64
   binary: api
   main: ./cmd/api
@@ -64,7 +64,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - -s -w
+    - -s -w -X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}}
 - id: api-windows-amd64
   binary: api
   main: ./cmd/api
@@ -78,6 +78,8 @@ builds:
   flags:
     - -trimpath
     - -buildmode=exe
+  ldflags:
+    - -s -w -X main.version={{.Version}} -X main.commit={{.FullCommit}} -X main.date={{.CommitDate}}
 
 archives:
   - id: api-archive

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -55,16 +55,21 @@ builds:
         - CGO_ENABLED=1
         - CC=oa64-clang
         - CXX=oa64-clang++
-# - binary: api-win
-#   id: api-win
-#  main: ./cmd/api
-#  goos:    
-#    - windows
-#  goarch:
-#    - amd64    
-#  env:
-#    - CGO_ENABLED=1
-#  ldflags: -s -w
+- binary: api-win
+  id: api-win
+  main: ./cmd/api
+  goos:    
+    - windows
+  goarch:
+    - amd64    
+  env:
+    - CGO_ENABLED=1
+    - CC=x86_64-w64-mingw32-gcc
+    - CXX=x86_64-w64-mingw32-g++
+  flags:
+    - -trimpath
+    - -buildmode=exe
+  ldflags: -s -w
   
 archives:
   - id: api-archive
@@ -72,11 +77,11 @@ archives:
     builds:
       - api
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .ShortCommit }}"
-  #- id: api-archive-win
-  #  format: zip
-  #  builds:
-  #    - api-win
-  #  name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"  
+  - id: api-archive-win
+    format: zip
+    builds:
+      - api-win
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .ShortCommit }}"
 
 checksum:
   disable: true

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -71,7 +71,7 @@ archives:
     format: tar.gz
     builds:
       - api
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .ShortCommit }}"
   #- id: api-archive-win
   #  format: zip
   #  builds:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -22,6 +22,39 @@ builds:
   env:
     - CGO_ENABLED=1
   ldflags: -s -w
+  overrides:
+    - goos: linux
+      goarch: amd64
+      goamd64: v1
+      env:
+        - CGO_ENABLED=1
+        - CC=x86_64-linux-gnu-gcc
+        - CXX=x86_64-linux-gnu-g++
+      ldflags:
+        - -s -w
+        - -extldflags "-static"
+    - goos: linux
+      goarch: arm64
+      env:
+        - CGO_ENABLED=1
+        - CC=aarch64-linux-gnu-gcc
+        - CXX=aarch64-linux-gnu-g++
+      ldflags:
+        - -s -w
+        - -extldflags "-static"
+    - goos: darwin
+      goarch: amd64
+      goamd64: v1
+      env:
+        - CGO_ENABLED=1
+        - CC=o64-clang
+        - CXX=o64-clang++
+    - goos: darwin
+      goarch: arm64
+      env:
+        - CGO_ENABLED=1
+        - CC=oa64-clang
+        - CXX=oa64-clang++
 # - binary: api-win
 #   id: api-win
 #  main: ./cmd/api

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -23,30 +23,6 @@ builds:
     - -trimpath
   ldflags:
     - -s -w
-  overrides:
-    - goos: linux
-      goarch: amd64
-      goamd64: v1
-      env:
-        - CGO_ENABLED=1
-        - CC=x86_64-linux-gnu-gcc
-        - CXX=x86_64-linux-gnu-g++
-      ldflags:
-        - -s -w
-        - -extldflags "-static"
-    - goos: linux
-      goarch: arm64
-      env:
-        - CGO_ENABLED=1
-        - CC=aarch64-linux-gnu-gcc
-        - CXX=aarch64-linux-gnu-g++
-      ldflags:
-        - -s -w
-        - -extldflags "-static"
-    - goos: darwin
-      goarch: arm64
-      env:
-        - CGO_ENABLED=1
 - id: api-darwin-arm64
   binary: api
   main: ./cmd/api

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -5,6 +5,7 @@ project_name: api
 builds:
 - binary: api
   id: api
+  main: ./cmd/api
   goos:
     - linux
     - darwin    
@@ -17,6 +18,7 @@ builds:
   ldflags: -s -w
 - binary: api-win
   id: api-win
+  main: ./cmd/api
   goos:    
     - windows
   goarch:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,27 +1,28 @@
 # goreleaser.yml
-
 before:
   hooks:
   - go mod tidy
 
+env:
+  - CGO_ENABLED=1
+
 project_name: api
 
 builds:
-- binary: api
-  id: api
+- id: api-darwin-amd64
+  binary: api
   main: ./cmd/api
-  goos:
-    - linux
-    - darwin    
   goarch:
     - amd64
-    - arm64
-  ignore:
-    - goos: linux
-      goarch: arm64
+  goos:
+    - darwin
   env:
-    - CGO_ENABLED=1
-  ldflags: -s -w
+    - CC=o64-clang
+    - CXX=o64-clang++
+  flags: 
+    - -trimpath
+  ldflags:
+    - -s -w
   overrides:
     - goos: linux
       goarch: amd64
@@ -43,44 +44,78 @@ builds:
         - -s -w
         - -extldflags "-static"
     - goos: darwin
-      goarch: amd64
-      goamd64: v1
-      env:
-        - CGO_ENABLED=1
-        - CC=o64-clang
-        - CXX=o64-clang++
-    - goos: darwin
       goarch: arm64
       env:
         - CGO_ENABLED=1
-        - CC=oa64-clang
-        - CXX=oa64-clang++
-- binary: api-win
-  id: api-win
+- id: api-darwin-arm64
+  binary: api
   main: ./cmd/api
-  goos:    
-    - windows
   goarch:
-    - amd64    
+    - arm64
+  goos:
+    - darwin   
   env:
-    - CGO_ENABLED=1
+    - CC=oa64-clang
+    - CXX=oa64-clang++
+  flags: 
+    - -trimpath
+  ldflags: 
+    - -s -w
+- id: api-linux-amd64
+  binary: api
+  main: ./cmd/api
+  goarch: 
+    - amd64
+  goos:
+    - linux
+  env:      
+    - CC=x86_64-linux-gnu-gcc
+    - CXX=x86_64-linux-gnu-g++
+  flags:
+    - -trimpath
+  ldflags:
+    - -s -w
+- id: api-linux-arm64
+  binary: api
+  main: ./cmd/api
+  goarch: 
+    - arm64
+  goos:
+    - linux
+  env:
+    - CC=aarch64-linux-gnu-gcc
+    - CXX=aarch64-linux-gnu-g++    
+  flags:
+    - -trimpath
+  ldflags:
+    - -s -w
+- id: api-windows-amd64
+  binary: api
+  main: ./cmd/api
+  goarch:
+    - amd64  
+  goos:    
+    - windows  
+  env:
     - CC=x86_64-w64-mingw32-gcc
     - CXX=x86_64-w64-mingw32-g++
   flags:
     - -trimpath
     - -buildmode=exe
-  ldflags: -s -w
-  
+
 archives:
   - id: api-archive
     format: tar.gz
     builds:
-      - api
+      - api-darwin-amd64
+      - api-darwin-arm64
+      - api-linux-amd64
+      - api-linux-arm64
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .ShortCommit }}"
   - id: api-archive-win
     format: zip
     builds:
-      - api-win
+      - api-windows-amd64
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .ShortCommit }}"
 
 checksum:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -22,16 +22,16 @@ builds:
   env:
     - CGO_ENABLED=1
   ldflags: -s -w
-- binary: api-win
-  id: api-win
-  main: ./cmd/api
-  goos:    
-    - windows
-  goarch:
-    - amd64    
-  env:
-    - CGO_ENABLED=1
-  ldflags: -s -w
+# - binary: api-win
+#   id: api-win
+#  main: ./cmd/api
+#  goos:    
+#    - windows
+#  goarch:
+#    - amd64    
+#  env:
+#    - CGO_ENABLED=1
+#  ldflags: -s -w
   
 archives:
   - id: api-archive
@@ -39,11 +39,11 @@ archives:
     builds:
       - api
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-  - id: api-archive-win
-    format: zip
-    builds:
-      - api-win
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"  
+  #- id: api-archive-win
+  #  format: zip
+  #  builds:
+  #    - api-win
+  #  name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"  
 
 checksum:
   disable: true

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,0 +1,39 @@
+# goreleaser.yml
+
+project_name: api
+
+builds:
+- binary: api
+  id: api
+  goos:
+    - linux
+    - darwin    
+  goarch:
+    - amd64
+    - arm64
+  ignore:
+    - goos: linux
+      goarch: arm64  
+  ldflags: -s -w
+- binary: api-win
+  id: api-win
+  goos:    
+    - windows
+  goarch:
+    - amd64    
+  ldflags: -s -w
+  
+archives:
+  - id: api-archive
+    format: tar.gz
+    builds:
+      - api
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+  - id: api-archive-win
+    format: zip
+    builds:
+      - api-win
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"  
+
+checksum:
+  disable: true


### PR DESCRIPTION
This PR adds goreleaser with goreleaser-cross wrapper to release cross platform binaries on ubuntu based machine on GitHub Actions.