### PR TITLE
Give write permissions to binaries workflow

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -3,6 +3,8 @@ on:
   release:
     types:
       - created
+permissions:
+  contents: write
 jobs:
   binaries:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Give permission to "binaries" workflow to attach the created binaries to the newly drafted release.